### PR TITLE
feat: add configuration scope visibility to all commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Global defaults for `last` and `limit` settings
   - Configuration priority: CLI flags > config file > defaults
   - Example configuration file provided (`.gitallica.yaml.example`)
+- **Configuration Visibility**: All commands now display active configuration details
+  - Shows config file path being used
+  - Displays analysis scope with expanded time windows (e.g., "last 7 days" instead of "7d")
+  - Indicates path filter source (CLI vs config) with proper pluralization
+  - Example: `Path filters: src/, lib/ (from CLI)` vs `Path filter: src/ (from config)`
 - **Enhanced CLI Experience**: Improved command-line interface with better path handling
   - Cross-platform path normalization for Windows/macOS/Linux compatibility
   - Backward compatibility maintained for single-path usage
@@ -23,15 +28,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Path Filtering**: Enhanced from single-path to multi-path support across all commands
 - **Configuration Management**: Centralized configuration system using Viper
+- **Configuration Precedence**: CLI flags now properly override config file settings
+- **Time Window Display**: Abbreviated formats (7d, 2m, 1y) now expand to readable format
+- **Command Name Formatting**: Hyphenated commands (bus-factor) display as "Bus Factor Analysis Scope"
+- **Path Filter Labels**: Dynamic singular/plural based on number of paths specified
 - **Documentation**: Updated README with comprehensive configuration examples and setup instructions
+
+### Fixed
+- **Deprecated Function**: Replaced `strings.Title` with custom `titleCase` function for Go 1.18+ compatibility
+- **Invalid Time Input**: Fallback now returns original string instead of misleading "last xyz"
+- **Config File Messages**: Generic "Using config file:" instead of assuming "project" config
 
 ### Technical Implementation
 - **Path Processing**: New `matchesPathFilter()` and `matchesSinglePathFilter()` utilities
 - **Configuration Integration**: `getConfigPaths()` helper for unified config/CLI handling
 - **Cross-Platform Support**: Proper path handling for different operating systems
 - **Backward Compatibility**: All existing single-path usage continues to work unchanged
-
-## [Unreleased]
 
 ## [1.0.0] - 2025-01-XX
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Every command now shows you exactly what configuration is being used:
 
 ```bash
 ❯ gitallica churn --last 7d --path README.md
-Using project config file: /Users/benricker/code/gitallica/.gitallica.yaml
+Using config file: /Users/benricker/code/gitallica/.gitallica.yaml
 === Churn Analysis Scope ===
 Time window: last 7 days
 Path filter: README.md (from CLI)

--- a/README.md
+++ b/README.md
@@ -150,6 +150,22 @@ gitallica churn --path README.md  # Overrides all config files
 - **Explicit**: `--config /path/to/config.yaml` flag
 - **CLI flags**: Always override configuration files
 
+**Configuration Visibility:**
+Every command now shows you exactly what configuration is being used:
+
+```bash
+❯ gitallica churn --last 7d --path README.md
+Using project config file: /Users/benricker/code/gitallica/.gitallica.yaml
+=== Churn Analysis Scope ===
+Time window: last 7 days
+Path filter: README.md (from CLI)
+```
+
+This helps you:
+- **Remember project settings** when working with multiple repositories
+- **Spot unintended configurations** when CLI flags override YAML settings
+- **Debug configuration issues** by seeing exactly what's being used
+
 ## Documentation
 
 - **[User Guide](docs/USER_GUIDE.md)** - Comprehensive usage guide

--- a/cmd/bus_factor.go
+++ b/cmd/bus_factor.go
@@ -797,11 +797,11 @@ Based on Martin Fowler's collective ownership principles and industry research.`
 	Run: func(cmd *cobra.Command, args []string) {
 		// Parse flags
 		lastArg, _ := cmd.Flags().GetString("last")
-		pathFilters := getConfigPaths(cmd, "bus-factor.paths")
+		pathFilters, source := getConfigPaths(cmd, "bus-factor.paths")
 		limitArg, _ := cmd.Flags().GetInt("limit")
 		
 		// Print configuration scope
-		printCommandScope(cmd, "bus-factor", lastArg, pathFilters)
+		printCommandScope(cmd, "bus-factor", lastArg, pathFilters, source)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/bus_factor.go
+++ b/cmd/bus_factor.go
@@ -799,6 +799,9 @@ Based on Martin Fowler's collective ownership principles and industry research.`
 		lastArg, _ := cmd.Flags().GetString("last")
 		pathFilters := getConfigPaths(cmd, "bus-factor.paths")
 		limitArg, _ := cmd.Flags().GetInt("limit")
+		
+		// Print configuration scope
+		printCommandScope(cmd, "bus-factor", lastArg, pathFilters)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/change_lead_time.go
+++ b/cmd/change_lead_time.go
@@ -97,6 +97,9 @@ The analysis identifies:
 		lastArg, _ := cmd.Flags().GetString("last")
 		limitArg, _ := cmd.Flags().GetInt("limit")
 		methodArg, _ := cmd.Flags().GetString("method")
+		
+		// Print configuration scope
+		printCommandScope(cmd, "change-lead-time", lastArg, pathFilters)
 
 		stats, err := analyzeChangeLeadTime(repo, pathFilters, lastArg, limitArg, methodArg)
 		if err != nil {

--- a/cmd/change_lead_time.go
+++ b/cmd/change_lead_time.go
@@ -93,13 +93,13 @@ The analysis identifies:
 			return fmt.Errorf("could not open repository: %v", err)
 		}
 
-		pathFilters := getConfigPaths(cmd, "change-lead-time.paths")
+		pathFilters, source := getConfigPaths(cmd, "change-lead-time.paths")
 		lastArg, _ := cmd.Flags().GetString("last")
 		limitArg, _ := cmd.Flags().GetInt("limit")
 		methodArg, _ := cmd.Flags().GetString("method")
 		
 		// Print configuration scope
-		printCommandScope(cmd, "change-lead-time", lastArg, pathFilters)
+		printCommandScope(cmd, "change-lead-time", lastArg, pathFilters, source)
 
 		stats, err := analyzeChangeLeadTime(repo, pathFilters, lastArg, limitArg, methodArg)
 		if err != nil {

--- a/cmd/churn.go
+++ b/cmd/churn.go
@@ -52,6 +52,13 @@ var churnCmd = &cobra.Command{
 This helps you understand whether your repo is growing sustainably 
 or accumulating complexity.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// Parse flags
+		lastArg, _ := cmd.Flags().GetString("last")
+		pathFilters := getConfigPaths(cmd, "churn.paths")
+		
+		// Print configuration scope
+		printCommandScope(cmd, "churn", lastArg, pathFilters)
+		
 		repo, err := git.PlainOpen(".")
 		if err != nil {
 			log.Fatalf("Could not open repository: %v", err)
@@ -67,8 +74,6 @@ or accumulating complexity.`,
 			log.Fatalf("Could not get commits: %v", err)
 		}
 
-		lastArg, _ := cmd.Flags().GetString("last")
-		pathFilters := getConfigPaths(cmd, "churn.paths")
 		since := time.Time{}
 		if lastArg != "" {
 			cutoff, err := parseDurationArg(lastArg)

--- a/cmd/churn.go
+++ b/cmd/churn.go
@@ -54,10 +54,10 @@ or accumulating complexity.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Parse flags
 		lastArg, _ := cmd.Flags().GetString("last")
-		pathFilters := getConfigPaths(cmd, "churn.paths")
+		pathFilters, source := getConfigPaths(cmd, "churn.paths")
 		
 		// Print configuration scope
-		printCommandScope(cmd, "churn", lastArg, pathFilters)
+		printCommandScope(cmd, "churn", lastArg, pathFilters, source)
 		
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/churn_files.go
+++ b/cmd/churn_files.go
@@ -279,12 +279,12 @@ Thresholds:
 	Run: func(cmd *cobra.Command, args []string) {
 		// Parse flags
 		lastArg, _ := cmd.Flags().GetString("last")
-		pathFilters := getConfigPaths(cmd, "churn-files.paths")
+		pathFilters, source := getConfigPaths(cmd, "churn-files.paths")
 		limitArg, _ := cmd.Flags().GetInt("limit")
 		showDirsArg, _ := cmd.Flags().GetBool("directories")
 		
 		// Print configuration scope
-		printCommandScope(cmd, "churn-files", lastArg, pathFilters)
+		printCommandScope(cmd, "churn-files", lastArg, pathFilters, source)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/churn_files.go
+++ b/cmd/churn_files.go
@@ -282,6 +282,9 @@ Thresholds:
 		pathFilters := getConfigPaths(cmd, "churn-files.paths")
 		limitArg, _ := cmd.Flags().GetInt("limit")
 		showDirsArg, _ := cmd.Flags().GetBool("directories")
+		
+		// Print configuration scope
+		printCommandScope(cmd, "churn-files", lastArg, pathFilters)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/commit_cadence.go
+++ b/cmd/commit_cadence.go
@@ -75,12 +75,12 @@ The analysis groups commits by time periods and identifies:
 			return fmt.Errorf("could not open repository: %v", err)
 		}
 
-		pathFilters := getConfigPaths(cmd, "commit-cadence.paths")
+		pathFilters, source := getConfigPaths(cmd, "commit-cadence.paths")
 		lastArg, _ := cmd.Flags().GetString("last")
 		periodArg, _ := cmd.Flags().GetString("period")
 		
 		// Print configuration scope
-		printCommandScope(cmd, "commit-cadence", lastArg, pathFilters)
+		printCommandScope(cmd, "commit-cadence", lastArg, pathFilters, source)
 
 		stats, err := analyzeCommitCadence(repo, pathFilters, lastArg, periodArg)
 		if err != nil {

--- a/cmd/commit_cadence.go
+++ b/cmd/commit_cadence.go
@@ -78,6 +78,9 @@ The analysis groups commits by time periods and identifies:
 		pathFilters := getConfigPaths(cmd, "commit-cadence.paths")
 		lastArg, _ := cmd.Flags().GetString("last")
 		periodArg, _ := cmd.Flags().GetString("period")
+		
+		// Print configuration scope
+		printCommandScope(cmd, "commit-cadence", lastArg, pathFilters)
 
 		stats, err := analyzeCommitCadence(repo, pathFilters, lastArg, periodArg)
 		if err != nil {

--- a/cmd/commit_size.go
+++ b/cmd/commit_size.go
@@ -250,6 +250,9 @@ Thresholds are based on research showing reviews are most effective under 400 li
 		limitArg, _ := cmd.Flags().GetInt("limit")
 		minRiskArg, _ := cmd.Flags().GetString("min-risk")
 		summaryArg, _ := cmd.Flags().GetBool("summary")
+		
+		// Print configuration scope
+		printCommandScope(cmd, "commit-size", lastArg, pathFilters)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/commit_size.go
+++ b/cmd/commit_size.go
@@ -246,13 +246,13 @@ Thresholds are based on research showing reviews are most effective under 400 li
 	Run: func(cmd *cobra.Command, args []string) {
 		// Parse flags
 		lastArg, _ := cmd.Flags().GetString("last")
-		pathFilters := getConfigPaths(cmd, "commit-size.paths")
+		pathFilters, source := getConfigPaths(cmd, "commit-size.paths")
 		limitArg, _ := cmd.Flags().GetInt("limit")
 		minRiskArg, _ := cmd.Flags().GetString("min-risk")
 		summaryArg, _ := cmd.Flags().GetBool("summary")
 		
 		// Print configuration scope
-		printCommandScope(cmd, "commit-size", lastArg, pathFilters)
+		printCommandScope(cmd, "commit-size", lastArg, pathFilters, source)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/dead_zones.go
+++ b/cmd/dead_zones.go
@@ -497,11 +497,11 @@ Based on Clean Code principles - untouched code becomes a liability over time.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Parse flags
 		lastArg, _ := cmd.Flags().GetString("last")
-		pathFilters := getConfigPaths(cmd, "dead-zones.paths")
+		pathFilters, source := getConfigPaths(cmd, "dead-zones.paths")
 		limitArg, _ := cmd.Flags().GetInt("limit")
 		
 		// Print configuration scope
-		printCommandScope(cmd, "dead-zones", lastArg, pathFilters)
+		printCommandScope(cmd, "dead-zones", lastArg, pathFilters, source)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/dead_zones.go
+++ b/cmd/dead_zones.go
@@ -499,6 +499,9 @@ Based on Clean Code principles - untouched code becomes a liability over time.`,
 		lastArg, _ := cmd.Flags().GetString("last")
 		pathFilters := getConfigPaths(cmd, "dead-zones.paths")
 		limitArg, _ := cmd.Flags().GetInt("limit")
+		
+		// Print configuration scope
+		printCommandScope(cmd, "dead-zones", lastArg, pathFilters)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/health_check.go
+++ b/cmd/health_check.go
@@ -558,6 +558,9 @@ Issues are ranked by severity and categorized for easy prioritization.`,
 		// Parse flags
 		lastArg, _ := cmd.Flags().GetString("last")
 		pathFilters := getConfigPaths(cmd, "health-check.paths")
+		
+		// Print configuration scope
+		printCommandScope(cmd, "health-check", lastArg, pathFilters)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/health_check.go
+++ b/cmd/health_check.go
@@ -557,10 +557,10 @@ Issues are ranked by severity and categorized for easy prioritization.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Parse flags
 		lastArg, _ := cmd.Flags().GetString("last")
-		pathFilters := getConfigPaths(cmd, "health-check.paths")
+		pathFilters, source := getConfigPaths(cmd, "health-check.paths")
 		
 		// Print configuration scope
-		printCommandScope(cmd, "health-check", lastArg, pathFilters)
+		printCommandScope(cmd, "health-check", lastArg, pathFilters, source)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/high_risk_commits.go
+++ b/cmd/high_risk_commits.go
@@ -73,12 +73,12 @@ architectural consideration.`,
 			return fmt.Errorf("could not open repository: %v", err)
 		}
 
-		pathFilters := getConfigPaths(cmd, "high-risk-commits.paths")
+		pathFilters, source := getConfigPaths(cmd, "high-risk-commits.paths")
 		lastArg, _ := cmd.Flags().GetString("last")
 		limitArg, _ := cmd.Flags().GetInt("limit")
 		
 		// Print configuration scope
-		printCommandScope(cmd, "high-risk-commits", lastArg, pathFilters)
+		printCommandScope(cmd, "high-risk-commits", lastArg, pathFilters, source)
 
 		stats, err := analyzeHighRiskCommits(repo, pathFilters, lastArg, limitArg)
 		if err != nil {

--- a/cmd/high_risk_commits.go
+++ b/cmd/high_risk_commits.go
@@ -76,6 +76,9 @@ architectural consideration.`,
 		pathFilters := getConfigPaths(cmd, "high-risk-commits.paths")
 		lastArg, _ := cmd.Flags().GetString("last")
 		limitArg, _ := cmd.Flags().GetInt("limit")
+		
+		// Print configuration scope
+		printCommandScope(cmd, "high-risk-commits", lastArg, pathFilters)
 
 		stats, err := analyzeHighRiskCommits(repo, pathFilters, lastArg, limitArg)
 		if err != nil {

--- a/cmd/long_lived_branches.go
+++ b/cmd/long_lived_branches.go
@@ -91,12 +91,12 @@ The analysis identifies:
 		}
 
 		lastArg, _ := cmd.Flags().GetString("last")
-		pathFilters := getConfigPaths(cmd, "long-lived-branches.paths")
+		pathFilters, source := getConfigPaths(cmd, "long-lived-branches.paths")
 		limitArg, _ := cmd.Flags().GetInt("limit")
 		showMergedArg, _ := cmd.Flags().GetBool("show-merged")
 		
 		// Print configuration scope
-		printCommandScope(cmd, "long-lived-branches", lastArg, pathFilters)
+		printCommandScope(cmd, "long-lived-branches", lastArg, pathFilters, source)
 
 		stats, err := analyzeLongLivedBranches(repo, pathFilters, lastArg, limitArg, showMergedArg)
 		if err != nil {

--- a/cmd/long_lived_branches.go
+++ b/cmd/long_lived_branches.go
@@ -90,11 +90,13 @@ The analysis identifies:
 			return fmt.Errorf("could not open repository: %v", err)
 		}
 
-		
 		lastArg, _ := cmd.Flags().GetString("last")
 		pathFilters := getConfigPaths(cmd, "long-lived-branches.paths")
 		limitArg, _ := cmd.Flags().GetInt("limit")
 		showMergedArg, _ := cmd.Flags().GetBool("show-merged")
+		
+		// Print configuration scope
+		printCommandScope(cmd, "long-lived-branches", lastArg, pathFilters)
 
 		stats, err := analyzeLongLivedBranches(repo, pathFilters, lastArg, limitArg, showMergedArg)
 		if err != nil {

--- a/cmd/onboarding_footprint.go
+++ b/cmd/onboarding_footprint.go
@@ -509,6 +509,9 @@ easy to read makes it easier to write." — Robert C. Martin, Clean Code`,
 		lastArg, _ := cmd.Flags().GetString("last")
 		limit, _ := cmd.Flags().GetInt("limit")
 		commitLimit, _ := cmd.Flags().GetInt("commit-limit")
+		
+		// Print configuration scope
+		printCommandScope(cmd, "onboarding-footprint", lastArg, pathFilters)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/onboarding_footprint.go
+++ b/cmd/onboarding_footprint.go
@@ -505,13 +505,13 @@ Complexity Classifications:
 easy to read makes it easier to write." — Robert C. Martin, Clean Code`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Parse flags
-		pathFilters := getConfigPaths(cmd, "onboarding-footprint.paths")
+		pathFilters, source := getConfigPaths(cmd, "onboarding-footprint.paths")
 		lastArg, _ := cmd.Flags().GetString("last")
 		limit, _ := cmd.Flags().GetInt("limit")
 		commitLimit, _ := cmd.Flags().GetInt("commit-limit")
 		
 		// Print configuration scope
-		printCommandScope(cmd, "onboarding-footprint", lastArg, pathFilters)
+		printCommandScope(cmd, "onboarding-footprint", lastArg, pathFilters, source)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/ownership_clarity.go
+++ b/cmd/ownership_clarity.go
@@ -452,12 +452,12 @@ Classifications:
 "With collective ownership, anyone can change any part of the code at any time." — Martin Fowler`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Parse flags
-		pathFilters := getConfigPaths(cmd, "ownership-clarity.paths")
+		pathFilters, source := getConfigPaths(cmd, "ownership-clarity.paths")
 		lastArg, _ := cmd.Flags().GetString("last")
 		limit, _ := cmd.Flags().GetInt("limit")
 		
 		// Print configuration scope
-		printCommandScope(cmd, "ownership-clarity", lastArg, pathFilters)
+		printCommandScope(cmd, "ownership-clarity", lastArg, pathFilters, source)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/ownership_clarity.go
+++ b/cmd/ownership_clarity.go
@@ -455,6 +455,9 @@ Classifications:
 		pathFilters := getConfigPaths(cmd, "ownership-clarity.paths")
 		lastArg, _ := cmd.Flags().GetString("last")
 		limit, _ := cmd.Flags().GetInt("limit")
+		
+		// Print configuration scope
+		printCommandScope(cmd, "ownership-clarity", lastArg, pathFilters)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,7 +112,7 @@ func initConfig() {
 	if err := projectViper.ReadInConfig(); err == nil {
 		// Merge project config into main viper (overrides home config)
 		mergeViperConfig(projectViper, viper.GetViper())
-		fmt.Fprintln(os.Stderr, "Using project config file:", projectViper.ConfigFileUsed())
+		fmt.Fprintln(os.Stderr, "Using config file:", projectViper.ConfigFileUsed())
 	} else if homeViper != nil && homeViper.ConfigFileUsed() != "" {
 		fmt.Fprintln(os.Stderr, "Using home config file:", homeViper.ConfigFileUsed())
 	}

--- a/cmd/survival.go
+++ b/cmd/survival.go
@@ -61,6 +61,9 @@ Helps spot unstable areas where code gets rewritten too frequently.`,
 		lastArg, _ := cmd.Flags().GetString("last")
 		pathFilters := getConfigPaths(cmd, "survival.paths")
 		debugArg, _ := cmd.Flags().GetBool("debug")
+		
+		// Print configuration scope
+		printCommandScope(cmd, "survival", lastArg, pathFilters)
 
 		// Parse --last argument
 		var cutoff time.Time

--- a/cmd/survival.go
+++ b/cmd/survival.go
@@ -59,11 +59,11 @@ Helps spot unstable areas where code gets rewritten too frequently.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Parse flags
 		lastArg, _ := cmd.Flags().GetString("last")
-		pathFilters := getConfigPaths(cmd, "survival.paths")
+		pathFilters, source := getConfigPaths(cmd, "survival.paths")
 		debugArg, _ := cmd.Flags().GetBool("debug")
 		
 		// Print configuration scope
-		printCommandScope(cmd, "survival", lastArg, pathFilters)
+		printCommandScope(cmd, "survival", lastArg, pathFilters, source)
 
 		// Parse --last argument
 		var cutoff time.Time

--- a/cmd/test_ratio.go
+++ b/cmd/test_ratio.go
@@ -306,6 +306,9 @@ Classifications:
 	Run: func(cmd *cobra.Command, args []string) {
 		// Parse flags
 		pathFilters := getConfigPaths(cmd, "test-ratio.paths")
+		
+		// Print configuration scope
+		printCommandScope(cmd, "test-ratio", "", pathFilters)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/test_ratio.go
+++ b/cmd/test_ratio.go
@@ -305,10 +305,10 @@ Classifications:
 "Test code is just as important as production code." — Robert C. Martin, Clean Code`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Parse flags
-		pathFilters := getConfigPaths(cmd, "test-ratio.paths")
+		pathFilters, source := getConfigPaths(cmd, "test-ratio.paths")
 		
 		// Print configuration scope
-		printCommandScope(cmd, "test-ratio", "", pathFilters)
+		printCommandScope(cmd, "test-ratio", "", pathFilters, source)
 
 		repo, err := git.PlainOpen(".")
 		if err != nil {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -23,6 +23,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -219,4 +220,67 @@ func getConfigPaths(cmd *cobra.Command, configKey string) []string {
 	}
 	
 	return []string{}
+}
+
+// expandTimeWindow converts abbreviated time windows to readable format
+func expandTimeWindow(lastArg string) string {
+	if lastArg == "" {
+		return "all time"
+	}
+	
+	// Handle common abbreviations
+	switch lastArg {
+	case "1d":
+		return "last 1 day"
+	case "2d":
+		return "last 2 days"
+	case "3d":
+		return "last 3 days"
+	case "7d":
+		return "last 7 days"
+	case "14d":
+		return "last 14 days"
+	case "30d":
+		return "last 30 days"
+	case "1m":
+		return "last 1 month"
+	case "2m":
+		return "last 2 months"
+	case "3m":
+		return "last 3 months"
+	case "6m":
+		return "last 6 months"
+	case "1y":
+		return "last 1 year"
+	case "2y":
+		return "last 2 years"
+	case "3y":
+		return "last 3 years"
+	default:
+		// For any other format, just prepend "last " to make it readable
+		return "last " + lastArg
+	}
+}
+
+// printCommandScope prints the configuration scope for a command
+func printCommandScope(cmd *cobra.Command, commandName string, lastArg string, pathFilters []string) {
+	// Print config file information if available
+	if viper.ConfigFileUsed() != "" {
+		fmt.Fprintf(os.Stderr, "Using config file: %s\n", viper.ConfigFileUsed())
+	}
+	
+	// Print command scope header
+	fmt.Fprintf(os.Stderr, "=== %s Analysis Scope ===\n", strings.Title(commandName))
+	
+	// Print time window with expanded format
+	fmt.Fprintf(os.Stderr, "Time window: %s\n", expandTimeWindow(lastArg))
+	
+	// Print path filters
+	if len(pathFilters) > 0 {
+		fmt.Fprintf(os.Stderr, "Path filter: %s\n", strings.Join(pathFilters, ", "))
+	} else {
+		fmt.Fprintf(os.Stderr, "Path filter: all files\n")
+	}
+	
+	fmt.Fprintf(os.Stderr, "\n")
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -272,8 +272,9 @@ func expandTimeWindow(lastArg string) string {
 	case "3y":
 		return "last 3 years"
 	default:
-		// For any other format, just prepend "last " to make it readable
-		return "last " + lastArg
+		// For any other format, return the original string unchanged to
+		// avoid misleading output
+		return lastArg
 	}
 }
 
@@ -281,11 +282,11 @@ func expandTimeWindow(lastArg string) string {
 func printCommandScope(cmd *cobra.Command, commandName string, lastArg string, pathFilters []string, source string) {
 	// Print config file information if available
 	if viper.ConfigFileUsed() != "" {
-		fmt.Fprintf(os.Stderr, "Using config file: %s\n", viper.ConfigFileUsed())
+		fmt.Fprintf(os.Stderr, "Using project config file: %s\n", viper.ConfigFileUsed())
 	}
 	
 	// Print command scope header
-	fmt.Fprintf(os.Stderr, "=== %s Analysis Scope ===\n", titleCase(commandName))
+	fmt.Fprintf(os.Stderr, "=== %s Analysis Scope ===\n", titleCase(strings.ReplaceAll(commandName, "-", " ")))
 	
 	// Print time window with expanded format
 	fmt.Fprintf(os.Stderr, "Time window: %s\n", expandTimeWindow(lastArg))

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -282,7 +282,7 @@ func expandTimeWindow(lastArg string) string {
 func printCommandScope(cmd *cobra.Command, commandName string, lastArg string, pathFilters []string, source string) {
 	// Print config file information if available
 	if viper.ConfigFileUsed() != "" {
-		fmt.Fprintf(os.Stderr, "Using project config file: %s\n", viper.ConfigFileUsed())
+		fmt.Fprintf(os.Stderr, "Using config file: %s\n", viper.ConfigFileUsed())
 	}
 	
 	// Print command scope header
@@ -293,7 +293,11 @@ func printCommandScope(cmd *cobra.Command, commandName string, lastArg string, p
 	
 	// Print path filters with source
 	if len(pathFilters) > 0 {
-		fmt.Fprintf(os.Stderr, "Path filter: %s %s\n", strings.Join(pathFilters, ", "), source)
+		label := "Path filter:"
+		if len(pathFilters) > 1 {
+			label = "Path filters:"
+		}
+		fmt.Fprintf(os.Stderr, "%s %s %s\n", label, strings.Join(pathFilters, ", "), source)
 	} else {
 		fmt.Fprintf(os.Stderr, "Path filter: all files\n")
 	}


### PR DESCRIPTION
### **User description**
Add configuration scope display to help users understand which config file and settings are being used when running commands. This addresses two key scenarios:

1. Multi-repository awareness - users can see when they're using a config file from another project
2. Configuration transparency - users can see when CLI flags override config file settings

Features:
- Shows config file path when available
- Displays expanded time window format (e.g., "last 2 years" vs "2y")
- Shows path filters or "all files" when none specified
- Consistent format across all 14 commands that use getConfigPaths()

Example output shows config file path, analysis scope header, time window, and path filters before the main command output.

Commands updated: churn, survival, bus-factor, dead-zones, test-ratio, churn-files, commit-size, health-check, ownership-clarity, onboarding-footprint, change-lead-time, long-lived-branches, high-risk-commits, commit-cadence

Addresses https://github.com/BGRicker/gitallica/issues/21


___

### **PR Type**
Enhancement


___

### **Description**
- Add configuration scope visibility to all 14 commands

- Display config file path, time window, and path filters

- Improve user transparency for multi-repository scenarios

- Standardize command output format across all commands


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Command Execution"] --> B["Parse Flags"]
  B --> C["printCommandScope()"]
  C --> D["Display Config File Path"]
  C --> E["Show Time Window"]
  C --> F["Show Path Filters"]
  D --> G["Main Command Logic"]
  E --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>utils.go</strong><dd><code>Add configuration scope display utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-5b14f474a50427ede31c39509d3921643c7f757a8c680f3a8bdf8c072e1c2160">+64/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bus_factor.go</strong><dd><code>Add configuration scope display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-f4864781debc26c1fed2ac5806f9850b2358977d85218abd9ce2704bffc31af9">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>change_lead_time.go</strong><dd><code>Add configuration scope display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-3592a8e128485700fea41c008c0ff5f896cabb2cba298d1af0086fd82e5aca73">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>churn.go</strong><dd><code>Add configuration scope display and reorganize flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-50d3124fb46bcd53f44728bed63dbe27055ea1ad539d7075143341af3d0e3c98">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>churn_files.go</strong><dd><code>Add configuration scope display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-14f3c88db22ba89d06489e8d38fa066adcda23fef3cd0e233f93b4d74fa5a643">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commit_cadence.go</strong><dd><code>Add configuration scope display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-04c26ea85993ee5a6218a3f57a436e268abe77ce2c63371a09e6430ae706b94d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commit_size.go</strong><dd><code>Add configuration scope display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-8d1203097c35de58205476558f78666005960edd9204446f737d701404450fd0">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dead_zones.go</strong><dd><code>Add configuration scope display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-98dd6de8073ec356165e5469698e9bdc776e330aedad2064da9502d2452c325e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_check.go</strong><dd><code>Add configuration scope display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-9ecb6c7691428ea1e6e784ecb9ab9ef6d5d36f1134f9c3f9e06caa6243a244cc">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>high_risk_commits.go</strong><dd><code>Add configuration scope display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-2fe706cff82c7b1067509f9995b88f5ccb97c86b039a771b427ed691fa819a97">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>long_lived_branches.go</strong><dd><code>Add configuration scope display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-3c38f41e74294d046a58812a317d1f043d369920e76db96d55a59cfa665c0653">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>onboarding_footprint.go</strong><dd><code>Add configuration scope display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-446ba32a488f2a552dae33992e14a6d3337eb64ef3588a310a07e3331e613cb4">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ownership_clarity.go</strong><dd><code>Add configuration scope display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-66cbdf1f174b9e75416a1a8337863a55e9dc9ae08099762440cd4c819bb807f5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>survival.go</strong><dd><code>Add configuration scope display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-b20a47433b831ec58e7abf76dc674df61052619d1a447893c0794ddd9b9febf6">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_ratio.go</strong><dd><code>Add configuration scope display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/gitallica/pull/27/files#diff-b2d89ac5c993fea42d7e83bc48c2d9986754beff8b02792a7d0c79b4a88040aa">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

